### PR TITLE
Update mock client scoring

### DIFF
--- a/Shared/BeatSaver/DownloadedSong.cs
+++ b/Shared/BeatSaver/DownloadedSong.cs
@@ -110,11 +110,10 @@ namespace TournamentAssistantShared.BeatSaver
             return node["_notes"].AsArray.Count;
         }
 
-        public int GetMaxScore(string characteristicSerializedName, BeatmapDifficulty difficulty)
+        public int GetMaxScore(string characteristicSerializedName, BeatmapDifficulty difficulty) => GetMaxScore(GetNoteCount(characteristicSerializedName, difficulty));
+        public int GetMaxScore(int noteCount)
         {
-            int noteCount = GetNoteCount(characteristicSerializedName, difficulty);
-
-            //Coptied from game files
+            //Copied from game files
             int num = 0;
             int num2 = 1;
             while (num2 < 8)


### PR DESCRIPTION
Updates to the mock client scoring
- Correctly handle accuracy based on number of notes elapsed so far
- Correctly handle the multiplier based on number of notes hit
- Update score data so all hits are between 100 and 115
- 0.5% chance to miss a note. Resets combo and modifies multiplier

Tested to the best of my ability. The multiplier system is a bit confusing but I'm pretty sure I got it right, although the code is a bit ugly.