### PR TITLE
add null value to  `_menuSceneSetupData.StartStandardLevel`

### DIFF
--- a/TournamentAssistant/Utilities/SongUtils.cs
+++ b/TournamentAssistant/Utilities/SongUtils.cs
@@ -188,7 +188,8 @@ new Pack
                     false,
                     false,  /* TODO: start paused? Worth looking into to replace the old hacky function */
                     null,
-                    (standardLevelScenesTransitionSetupData, results) => songFinishedCallback?.Invoke(standardLevelScenesTransitionSetupData, results)
+                    (standardLevelScenesTransitionSetupData, results) => songFinishedCallback?.Invoke(standardLevelScenesTransitionSetupData, results),
+                    null
                 );
             };
 


### PR DESCRIPTION
This is tested locally on my machine with latest TA release. Beat Games added a RestartLevelCallback to the StartStandardLevel method, making TA actively panic when starting a map. Worth noting this happened in the 1.25 release of the game.