### PR TITLE
Added missing translation string. Read Desc:

### DIFF
--- a/TournamentAssistant/Localization/da.json
+++ b/TournamentAssistant/Localization/da.json
@@ -22,6 +22,7 @@
   "port": "Port",
   "qualifiers": "Kvalifikationer",
   "qualifiers_hint": "Spil kvalifikations-sangene for turneringen!",
+  "qualifier_room": "Kvalifikations rum",
   "quotes": [
     "En sand mester giver det altid en chance til.",
     "Du misser 100% af de chancer du aldrig tager.",

--- a/TournamentAssistant/Localization/en.json
+++ b/TournamentAssistant/Localization/en.json
@@ -22,6 +22,7 @@
 	"port": "Port",
 	"qualifiers": "Qualifiers",
 	"qualifiers_hint": "Play the qualifier songs for the tournament!",
+	"qualifier_room": "Qualifier room",
 	"quotes": [
 		"It’s hard to beat a person who never gives up.",
 		"You're off to great places, today is your day.",

--- a/TournamentAssistant/Localization/it.json
+++ b/TournamentAssistant/Localization/it.json
@@ -22,6 +22,7 @@
   "port": "Port",
   "qualifiers": "Qualifiche",
   "qualifiers_hint": "Gioca le canzoni di qualifica per il torneo!",
+  "qualifier_room": "Stanza delle Qualifiche",
   "quotes": [
     "È difficile battere una persona che non si arrende mai.",
     "Andrai lontano, oggi è il tuo giorno.",

--- a/TournamentAssistant/Localization/ko.json
+++ b/TournamentAssistant/Localization/ko.json
@@ -22,6 +22,7 @@
 	"port": "포트",
 	"qualifiers": "예선",
 	"qualifiers_hint": "토너먼트 예선 곡들을 플레이합니다!",
+	"qualifier_room": "Qualifier room",
 	"quotes": [
 		"절대 포기하지 않는 사람을 이기는 건 어렵다.",
 		"먼 걸음을 하셨네요. 오늘은 당신의 날입니다.",

--- a/TournamentAssistant/Localization/nb.json
+++ b/TournamentAssistant/Localization/nb.json
@@ -22,6 +22,7 @@
   "port": "Port",
   "qualifiers": "Kvalifiseringer",
   "qualifiers_hint": "Spill kvalifiserings sangene for turneringen.",
+  "qualifier_room": "Kvalifiseringsrom",
   "quotes": [
     "Tro ikke mørket når lyset går ned i skumringens fang.\nAltid er det på jorden et sted soloppgang.",
     "Det er i motbakker det går oppover.",

--- a/TournamentAssistant/Localization/nl.json
+++ b/TournamentAssistant/Localization/nl.json
@@ -22,6 +22,7 @@
   "port": "Poort",
   "qualifiers": "Kwalificatie Ronde",
   "qualifiers_hint": "Speel de kwalificatie nummers voor het toernooi!",
+  "qualifier_room": "Kwalificatie Ronde Kamer",
   "quotes": [
     "Kunnen we Flevoland weer onder water zetten?",
     "Bewegen is Gezond!",

--- a/TournamentAssistant/Localization/owo.json
+++ b/TournamentAssistant/Localization/owo.json
@@ -22,6 +22,7 @@
   "port": "powt",
   "qualifiers": "quawifiews",
   "qualifiers_hint": "pway the quawifiew songs fow the touwnament!",
+  "qualifier_room": "quawifiew w-woom OwO",
   "quotes": [
     "it’s hawd to beat a pewson who nevew gives up.",
     "you'we off to gweat pwaces, today is youw day.",


### PR DESCRIPTION

### What:
- The `qualifier_room`-string has been added.

### Why:
UI would break when entering a qualifier-room, and disappear because of the missing string, straight up locking you in the room, forcing you to restart the game to get out.

#

I've tested them all, and they all return full funcationality to the UI.

The Korean qualifier_room string is <ins>**still in english**</ins>, and should be translated.