### PR TITLE
Refactor account lookup logic and add BeatLeader and ScoreSaber

### DIFF
--- a/TournamentAssistantServer/PacketHandlers/Requests.cs
+++ b/TournamentAssistantServer/PacketHandlers/Requests.cs
@@ -523,48 +523,31 @@ namespace TournamentAssistantServer.PacketHandlers
                 TournamentId = getAuthorizedUsers.TournamentId,
             };
 
-            // TOOO: Guess we actually need to use the steam api. Oh well. In the meantime...
             var authorizedUsers = tournamentDatabase.AuthorizedUsers
                 .Where(x => !x.Old && x.TournamentId == getAuthorizedUsers.TournamentId)
                 .ToList();
-            if (authorizedUsers.Count > 10)
+
+            var accountInfos = await AccountLookup.GetAccountInfos(QualifierBot, DatabaseService, authorizedUsers.Select(x => x.DiscordId));
+            response.AuthorizedUsers.AddRange(authorizedUsers.Select(x =>
             {
-                response.AuthorizedUsers.AddRange(
-                    authorizedUsers
-                    .Select(x =>
+                var accountInfo = accountInfos.TryGetValue(x.DiscordId, out var resolvedInfo)
+                    ? resolvedInfo
+                    : new User.DiscordInfo
                     {
-                        var response = new Response.GetAuthorizedUsers.AuthroizedUser
-                        {
-                            DiscordId = x.DiscordId,
-                            DiscordUsername = "Hi Jive, you rate limit causing dummy",
-                            DiscordAvatarUrl = "https://cdn.discordapp.com/avatars/708801604719214643/d37a1b93a741284ecd6e57569f6cd598.webp?size=100",
-                        };
-                        response.Roles.AddRange(x.Roles.Split(","));
-                        return response;
-                    }
-                ));
-            }
-            else
-            {
-                // We actually fetch pfp and username from discord (or steam) in realtime for this. Heavy, yes, but
-                // Discord.NET takes care of caching and avoiding rate limits for us...
-                // for discord. We'll have to handle the rate limiting of other services
-                // (lookin at you, steam) on our own
-                response.AuthorizedUsers.AddRange(await Task.WhenAll(authorizedUsers
-                    .Select(async x =>
-                    {
-                        var discordUserInfo = await AccountLookup.GetAccountInfo(QualifierBot, DatabaseService, x.DiscordId);
-                        var response = new Response.GetAuthorizedUsers.AuthroizedUser
-                        {
-                            DiscordId = x.DiscordId,
-                            DiscordUsername = discordUserInfo.Username,
-                            DiscordAvatarUrl = discordUserInfo.AvatarUrl,
-                        };
-                        response.Roles.AddRange(x.Roles.Split(","));
-                        return response;
-                    }
-                )));
-            }
+                        UserId = x.DiscordId,
+                        Username = "[UNKNOWN USER]",
+                        AvatarUrl = "https://cdn.discordapp.com/avatars/708801604719214643/d37a1b93a741284ecd6e57569f6cd598.webp?size=100",
+                    };
+
+                var userResponse = new Response.GetAuthorizedUsers.AuthroizedUser
+                {
+                    DiscordId = x.DiscordId,
+                    DiscordUsername = accountInfo.Username,
+                    DiscordAvatarUrl = accountInfo.AvatarUrl,
+                };
+                userResponse.Roles.AddRange(x.Roles.Split(","));
+                return userResponse;
+            }));
 
             return response;
         }

--- a/TournamentAssistantServer/Utilities/AccountLookup.cs
+++ b/TournamentAssistantServer/Utilities/AccountLookup.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using System;
 using TournamentAssistantShared.Models;
 using TournamentAssistantShared;
@@ -9,60 +11,139 @@ namespace TournamentAssistantServer.Utilities
 {
     public class AccountLookup
     {
+        private const string DefaultAvatarUrl = "https://cdn.discordapp.com/avatars/708801604719214643/d37a1b93a741284ecd6e57569f6cd598.webp?size=100";
+
         public static async Task<User.DiscordInfo> GetAccountInfo(QualifierBot qualifierBot, DatabaseService databaseService, string accountId)
         {
-            var name = "";
-            var avatarUrl = "https://cdn.discordapp.com/avatars/708801604719214643/d37a1b93a741284ecd6e57569f6cd598.webp?size=100";
+            var allInfos = await GetAccountInfos(qualifierBot, databaseService, new[] { accountId });
+            return allInfos.TryGetValue(accountId, out var info)
+                ? info
+                : new User.DiscordInfo
+                {
+                    UserId = accountId,
+                    Username = "[OCULUS USER]",
+                    AvatarUrl = DefaultAvatarUrl,
+                };
+        }
 
-            // If accountId is a guid, we're dealing with a bot token
-            if (Guid.TryParse(accountId, out var _))
+        public static async Task<Dictionary<string, User.DiscordInfo>> GetAccountInfos(QualifierBot qualifierBot, DatabaseService databaseService, IEnumerable<string> accountIds)
+        {
+            var distinctIds = accountIds
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct()
+                .ToList();
+
+            var results = new Dictionary<string, User.DiscordInfo>();
+            var unresolved = new HashSet<string>(distinctIds);
+
+            ResolveBotTokenUsers(databaseService, unresolved, results);
+            await ResolveDiscordUsers(qualifierBot, unresolved, results);
+
+            if (unresolved.Count > 0)
             {
-                var userDatabase = databaseService.NewUserDatabaseContext();
-                var botUser = userDatabase.GetUser(accountId);
-
-                name = botUser?.Name ?? "[TOKEN NOT FOUND]";
+                var scoreSaberProfiles = await ScoreSaberAccountLookup.GetProfilesAsync(unresolved);
+                foreach (var pair in scoreSaberProfiles)
+                {
+                    results[pair.Key] = new User.DiscordInfo
+                    {
+                        UserId = pair.Key,
+                        Username = pair.Value.DisplayName,
+                        AvatarUrl = string.IsNullOrWhiteSpace(pair.Value.AvatarUrl) ? DefaultAvatarUrl : pair.Value.AvatarUrl,
+                    };
+                    unresolved.Remove(pair.Key);
+                }
             }
 
-            // If we don't have a bot token on our hands, maybe we have a discord id?
-            else if (string.IsNullOrEmpty(name) && (accountId.Length >= 17 && accountId.Length <= 19))
+            if (unresolved.Count > 0)
             {
-                Logger.Warning($"Looking up info for discord user: {accountId}");
-                var userInfo = await qualifierBot.GetAccountInfo(accountId);
-
-                name = userInfo.Item1;
-                avatarUrl = userInfo.Item2;
+                var beatLeaderProfiles = await BeatLeaderAccountLookup.GetProfilesAsync(unresolved);
+                foreach (var pair in beatLeaderProfiles)
+                {
+                    results[pair.Key] = new User.DiscordInfo
+                    {
+                        UserId = pair.Key,
+                        Username = pair.Value.DisplayName,
+                        AvatarUrl = string.IsNullOrWhiteSpace(pair.Value.AvatarUrl) ? DefaultAvatarUrl : pair.Value.AvatarUrl,
+                    };
+                    unresolved.Remove(pair.Key);
+                }
             }
 
-            // If we still don't have any info, maybe it was a steam ID?
-            else if (string.IsNullOrEmpty(name) && accountId.Length == 17)
+            foreach (var unresolvedId in unresolved)
             {
-                Logger.Warning($"Looking up info for steam user: {accountId}");
+                results[unresolvedId] = new User.DiscordInfo
+                {
+                    UserId = unresolvedId,
+                    Username = "[OCULUS USER]",
+                    AvatarUrl = DefaultAvatarUrl,
+                };
+            }
 
+            return results;
+        }
+
+        private static void ResolveBotTokenUsers(DatabaseService databaseService, HashSet<string> unresolved, Dictionary<string, User.DiscordInfo> results)
+        {
+            var tokenIds = unresolved.Where(x => Guid.TryParse(x, out _)).ToList();
+            if (tokenIds.Count == 0)
+            {
+                return;
+            }
+
+            using var userDatabase = databaseService.NewUserDatabaseContext();
+            foreach (var tokenId in tokenIds)
+            {
+                var botUser = userDatabase.GetUser(tokenId);
+                results[tokenId] = new User.DiscordInfo
+                {
+                    UserId = tokenId,
+                    Username = botUser?.Name ?? "[TOKEN NOT FOUND]",
+                    AvatarUrl = DefaultAvatarUrl,
+                };
+                unresolved.Remove(tokenId);
+            }
+        }
+
+        private static async Task ResolveDiscordUsers(QualifierBot qualifierBot, HashSet<string> unresolved, Dictionary<string, User.DiscordInfo> results)
+        {
+            if (qualifierBot == null)
+            {
+                return;
+            }
+
+            var discordCandidateIds = unresolved.Where(IsPossibleDiscordId).ToList();
+            foreach (var discordId in discordCandidateIds)
+            {
                 try
                 {
-                    var steamInfo = await SteamAccountLookup.GetProfileFromSteamId64Async(accountId);
-
-                    name = steamInfo.SteamID;
-                    avatarUrl = steamInfo.AvatarIcon;
+                    Logger.Warning($"Looking up info for discord user: {discordId}");
+                    var userInfo = await qualifierBot.GetAccountInfo(discordId);
+                    if (!string.IsNullOrWhiteSpace(userInfo.Item1))
+                    {
+                        results[discordId] = new User.DiscordInfo
+                        {
+                            UserId = discordId,
+                            Username = userInfo.Item1,
+                            AvatarUrl = string.IsNullOrWhiteSpace(userInfo.Item2) ? DefaultAvatarUrl : userInfo.Item2,
+                        };
+                        unresolved.Remove(discordId);
+                    }
                 }
                 catch
                 {
-                    name = $"{accountId} (stop rate limiting me you dummy)";
+                    // Keep unresolved. We'll try ScoreSaber, then BeatLeader.
                 }
             }
+        }
 
-            // If we STILL don't have any info, it's probably an Oculus ID, and there's nothing I can do about that
-            else if (string.IsNullOrEmpty(name))
+        private static bool IsPossibleDiscordId(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value.Length < 17 || value.Length > 19)
             {
-                name = "[OCULUS USER]";
+                return false;
             }
 
-            return new User.DiscordInfo
-            {
-                UserId = accountId,
-                Username = name,
-                AvatarUrl = avatarUrl,
-            };
+            return value.All(char.IsDigit);
         }
     }
 }

--- a/TournamentAssistantServer/Utilities/AccountLookup.cs
+++ b/TournamentAssistantServer/Utilities/AccountLookup.cs
@@ -138,7 +138,7 @@ namespace TournamentAssistantServer.Utilities
 
         private static bool IsPossibleDiscordId(string value)
         {
-            if (string.IsNullOrWhiteSpace(value) || value.Length < 17 || value.Length > 19)
+            if (string.IsNullOrWhiteSpace(value) || value.Length < 17 || value.Length > 19 || value.StartsWith("765"))
             {
                 return false;
             }

--- a/TournamentAssistantServer/Utilities/AccountLookup.cs
+++ b/TournamentAssistantServer/Utilities/AccountLookup.cs
@@ -37,7 +37,6 @@ namespace TournamentAssistantServer.Utilities
             var unresolved = new HashSet<string>(distinctIds);
 
             ResolveBotTokenUsers(databaseService, unresolved, results);
-            await ResolveDiscordUsers(qualifierBot, unresolved, results);
 
             if (unresolved.Count > 0)
             {
@@ -67,6 +66,11 @@ namespace TournamentAssistantServer.Utilities
                     };
                     unresolved.Remove(pair.Key);
                 }
+            }
+
+            if(unresolved.Count > 0)
+            {
+                await ResolveDiscordUsers(qualifierBot, unresolved, results);
             }
 
             foreach (var unresolvedId in unresolved)
@@ -138,7 +142,7 @@ namespace TournamentAssistantServer.Utilities
 
         private static bool IsPossibleDiscordId(string value)
         {
-            if (string.IsNullOrWhiteSpace(value) || value.Length < 17 || value.Length > 19 || value.StartsWith("765"))
+            if (string.IsNullOrWhiteSpace(value) || value.Length < 17 || value.Length > 19)
             {
                 return false;
             }

--- a/TournamentAssistantServer/Utilities/BeatLeaderAccountLookup.cs
+++ b/TournamentAssistantServer/Utilities/BeatLeaderAccountLookup.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TournamentAssistantShared;
+
+namespace TournamentAssistantServer.Utilities
+{
+    public class BeatLeaderAccountLookup
+    {
+        private static readonly HttpClient client = new HttpClient
+        {
+            BaseAddress = new Uri("https://api.beatleader.com")
+        };
+
+        private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private static readonly ConcurrentDictionary<string, ScoreSaberAccountLookup.ExternalAccountProfile> cache = new ConcurrentDictionary<string, ScoreSaberAccountLookup.ExternalAccountProfile>();
+
+        private const int MaxConcurrentRequests = 8;
+
+        public static async Task<Dictionary<string, ScoreSaberAccountLookup.ExternalAccountProfile>> GetProfilesAsync(IEnumerable<string> accountIds)
+        {
+            var ids = accountIds
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct()
+                .ToList();
+
+            var results = new ConcurrentDictionary<string, ScoreSaberAccountLookup.ExternalAccountProfile>();
+            var missingIds = new List<string>();
+
+            foreach (var id in ids)
+            {
+                if (cache.TryGetValue(id, out var cachedProfile) && cachedProfile != null)
+                {
+                    results[id] = CloneProfile(cachedProfile, id);
+                }
+                else
+                {
+                    missingIds.Add(id);
+                }
+            }
+
+            using var semaphore = new SemaphoreSlim(MaxConcurrentRequests);
+            var tasks = missingIds.Select(async id =>
+            {
+                await semaphore.WaitAsync();
+                try
+                {
+                    var fetchedProfile = await GetProfileInternalAsync(id);
+                    if (fetchedProfile == null)
+                    {
+                        return;
+                    }
+
+                    // Map the fetched profile to all known linked IDs so future lookups can be served from cache.
+                    var knownIds = new[] { id, fetchedProfile.Id, fetchedProfile.SteamId, fetchedProfile.OculusPCId }
+                        .Where(x => !string.IsNullOrWhiteSpace(x))
+                        .Distinct()
+                        .ToList();
+
+                    var normalizedProfile = new ScoreSaberAccountLookup.ExternalAccountProfile
+                    {
+                        RequestedId = id,
+                        PlayerId = fetchedProfile.Id,
+                        DisplayName = fetchedProfile.Name,
+                        AvatarUrl = fetchedProfile.Avatar,
+                    };
+
+                    foreach (var knownId in knownIds)
+                    {
+                        cache[knownId] = normalizedProfile;
+                    }
+
+                    results[id] = CloneProfile(normalizedProfile, id);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            }).ToArray();
+
+            await Task.WhenAll(tasks);
+
+            // If an id was not directly found, but became cached as a linked id from another lookup, include it.
+            foreach (var id in ids)
+            {
+                if (!results.ContainsKey(id) && cache.TryGetValue(id, out var cachedProfile) && cachedProfile != null)
+                {
+                    results[id] = CloneProfile(cachedProfile, id);
+                }
+            }
+
+            return results.ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        private static async Task<BeatLeaderPlayerDto> GetProfileInternalAsync(string accountId)
+        {
+            try
+            {
+                using var response = await client.GetAsync($"/player/{accountId}?stats=false");
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var payload = await response.Content.ReadAsStringAsync();
+                var dto = JsonSerializer.Deserialize<BeatLeaderPlayerDto>(payload, jsonOptions);
+                if (dto == null || string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.Name))
+                {
+                    return null;
+                }
+
+                return dto;
+            }
+            catch (Exception e)
+            {
+                Logger.Warning($"BeatLeader lookup failed for {accountId}: {e.Message}");
+                return null;
+            }
+        }
+
+        private static ScoreSaberAccountLookup.ExternalAccountProfile CloneProfile(ScoreSaberAccountLookup.ExternalAccountProfile profile, string requestedId)
+        {
+            return new ScoreSaberAccountLookup.ExternalAccountProfile
+            {
+                RequestedId = requestedId,
+                PlayerId = profile.PlayerId,
+                DisplayName = profile.DisplayName,
+                AvatarUrl = profile.AvatarUrl,
+            };
+        }
+
+        private class BeatLeaderPlayerDto
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Avatar { get; set; }
+            public BeatLeaderLinkedIdsDto LinkedIds { get; set; }
+
+            public string SteamId => LinkedIds?.SteamId;
+            public string OculusPCId => LinkedIds?.OculusPCId;
+        }
+
+        private class BeatLeaderLinkedIdsDto
+        {
+            public string SteamId { get; set; }
+            public string OculusPCId { get; set; }
+        }
+    }
+}

--- a/TournamentAssistantServer/Utilities/ScoreSaberAccountLookup.cs
+++ b/TournamentAssistantServer/Utilities/ScoreSaberAccountLookup.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TournamentAssistantShared;
+
+namespace TournamentAssistantServer.Utilities
+{
+    public class ScoreSaberAccountLookup
+    {
+        public class ExternalAccountProfile
+        {
+            public string RequestedId { get; set; }
+            public string PlayerId { get; set; }
+            public string DisplayName { get; set; }
+            public string AvatarUrl { get; set; }
+        }
+
+        private static readonly HttpClient client = new HttpClient
+        {
+            BaseAddress = new Uri("https://scoresaber.com")
+        };
+
+        private static readonly JsonSerializerOptions jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        private static readonly ConcurrentDictionary<string, ExternalAccountProfile> cache = new ConcurrentDictionary<string, ExternalAccountProfile>();
+
+        // ScoreSaber rate limit is generous (400 rpm), but we still keep concurrency bounded.
+        private const int MaxConcurrentRequests = 8;
+
+        public static async Task<Dictionary<string, ExternalAccountProfile>> GetProfilesAsync(IEnumerable<string> accountIds)
+        {
+            var ids = accountIds
+                .Where(x => !string.IsNullOrWhiteSpace(x))
+                .Distinct()
+                .ToList();
+
+            var results = new ConcurrentDictionary<string, ExternalAccountProfile>();
+            var missingIds = new List<string>();
+
+            foreach (var id in ids)
+            {
+                if (cache.TryGetValue(id, out var cachedProfile) && cachedProfile != null)
+                {
+                    results[id] = CloneProfile(cachedProfile, id);
+                }
+                else
+                {
+                    missingIds.Add(id);
+                }
+            }
+
+            using var semaphore = new SemaphoreSlim(MaxConcurrentRequests);
+            var tasks = missingIds.Select(async id =>
+            {
+                await semaphore.WaitAsync();
+                try
+                {
+                    var profile = await GetProfileInternalAsync(id);
+                    if (profile != null)
+                    {
+                        cache[id] = profile;
+                        results[id] = CloneProfile(profile, id);
+                    }
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+
+            await Task.WhenAll(tasks);
+
+            return results.ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        private static async Task<ExternalAccountProfile> GetProfileInternalAsync(string accountId)
+        {
+            try
+            {
+                using var response = await client.GetAsync($"/api/player/{accountId}/basic");
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+
+                response.EnsureSuccessStatusCode();
+
+                var payload = await response.Content.ReadAsStringAsync();
+                var dto = JsonSerializer.Deserialize<ScoreSaberPlayerDto>(payload, jsonOptions);
+                if (dto == null || string.IsNullOrWhiteSpace(dto.Id) || string.IsNullOrWhiteSpace(dto.Name))
+                {
+                    return null;
+                }
+
+                return new ExternalAccountProfile
+                {
+                    RequestedId = accountId,
+                    PlayerId = dto.Id,
+                    DisplayName = dto.Name,
+                    AvatarUrl = dto.ProfilePicture,
+                };
+            }
+            catch (Exception e)
+            {
+                Logger.Warning($"ScoreSaber lookup failed for {accountId}: {e.Message}");
+                return null;
+            }
+        }
+
+        private static ExternalAccountProfile CloneProfile(ExternalAccountProfile profile, string requestedId)
+        {
+            return new ExternalAccountProfile
+            {
+                RequestedId = requestedId,
+                PlayerId = profile.PlayerId,
+                DisplayName = profile.DisplayName,
+                AvatarUrl = profile.AvatarUrl,
+            };
+        }
+
+        private class ScoreSaberPlayerDto
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string ProfilePicture { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Now instead of using the Steam api we use the ScoreSaber and BeatLeader apis. ScoreSaber already has a large rate limit (400 requests per min) and beatleader allows us to batch requests, but since we use it as a fallback it's probably not needed. 

I also added caching so it doesn't re-fetch user profiles every single time, but if they have already been cached it just resolves from cache :D 

Requests.cs was also updated so that it no longer rate limits poor Jive and now falls back on [UNKNOWN USER] instead of [OCULUS USER]. The steam account lookup helper was not removed, but should now be unused. This still doesn't stop people from adding users who don't have an account on either scoresaber or beatleader(which is highly unlikely in this community), it will simply not resolve them