### PR TITLE
Fix song detail map selection (IBeatmapLevel version)

### DIFF
--- a/TournamentAssistant/UI/FlowCoordinators/QualifierCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/QualifierCoordinator.cs
@@ -224,9 +224,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
 
             PresentViewController(_songDetail, () =>
             {
-                _songDetail.SetSelectedSong(loadedLevel);
-                _songDetail.SetSelectedCharacteristic(map.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                _songDetail.SetSelectedDifficulty(map.GameplayParameters.Beatmap.Difficulty);
+                _songDetail.SetSelectedSong(loadedLevel, map);
 
                 _gameplaySetupViewController.Setup(true, true, true, false, PlayerSettingsPanelController.PlayerSettingsPanelLayout.Singleplayer);
                 SetLeftScreenViewController(_gameplaySetupViewController, ViewController.AnimationType.In);

--- a/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
@@ -309,6 +309,12 @@ namespace TournamentAssistant.UI.FlowCoordinators
 
             await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
             {
+                if (Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId?.ToUpper() != levelId.ToUpper())
+                {
+                    Logger.Error($"Unable to show loaded song '{levelId}' because the selected match map is '{Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId}'");
+                    return;
+                }
+
                 // Load the song, then display the detail info
                 if (!_songDetail.isInViewControllerHierarchy)
                 {
@@ -317,9 +323,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
                         _songDetail.DisableCharacteristicControl = true;
                         _songDetail.DisableDifficultyControl = true;
                         _songDetail.DisablePlayButton = true;
-                        _songDetail.SetSelectedSong(loadedLevel);
-                        _songDetail.SetSelectedCharacteristic(Match.SelectedMap.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                        _songDetail.SetSelectedDifficulty(Match.SelectedMap.GameplayParameters.Beatmap.Difficulty);
+                        _songDetail.SetSelectedSong(loadedLevel, Match.SelectedMap);
                     }, immediately: true);
                 }
                 else
@@ -327,9 +331,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
                     _songDetail.DisableCharacteristicControl = true;
                     _songDetail.DisableDifficultyControl = true;
                     _songDetail.DisablePlayButton = true;
-                    _songDetail.SetSelectedSong(loadedLevel);
-                    _songDetail.SetSelectedCharacteristic(Match.SelectedMap.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                    _songDetail.SetSelectedDifficulty(Match.SelectedMap.GameplayParameters.Beatmap.Difficulty);
+                    _songDetail.SetSelectedSong(loadedLevel, Match.SelectedMap);
                 }
             });
         }
@@ -358,6 +360,11 @@ namespace TournamentAssistant.UI.FlowCoordinators
         {
             if (match.MatchEquals(Match))
             {
+                // Identify if this is a map change.
+                // Because map change events are followed by a load_song event,
+                // we want to avoid updating the detail view twice for the same map change
+                var selectedMapChanged = Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId != match.SelectedMap?.GameplayParameters?.Beatmap?.LevelId;
+
                 Match = match;
                 _playerList.Players = Client.StateManager
                     .GetUsers(Client.SelectedTournament)
@@ -380,8 +387,11 @@ namespace TournamentAssistant.UI.FlowCoordinators
                 {
                     RemoveSelfFromMatch();
                 }
+                // Map updates arrive before the load_song request
+                // Let that path initialize the detail view for new maps
                 else if (_songDetail && _songDetail.isInViewControllerHierarchy &&
-                         match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null)
+                         match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null &&
+                         !selectedMapChanged)
                 {
                     await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
                     {

--- a/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
@@ -309,12 +309,6 @@ namespace TournamentAssistant.UI.FlowCoordinators
 
             await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
             {
-                if (Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId?.ToUpper() != levelId.ToUpper())
-                {
-                    Logger.Error($"Unable to show loaded song '{levelId}' because the selected match map is '{Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId}'");
-                    return;
-                }
-
                 // Load the song, then display the detail info
                 if (!_songDetail.isInViewControllerHierarchy)
                 {

--- a/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
@@ -360,11 +360,6 @@ namespace TournamentAssistant.UI.FlowCoordinators
         {
             if (match.MatchEquals(Match))
             {
-                // Identify if this is a map change.
-                // Because map change events are followed by a load_song event,
-                // we want to avoid updating the detail view twice for the same map change
-                var selectedMapChanged = Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId != match.SelectedMap?.GameplayParameters?.Beatmap?.LevelId;
-
                 Match = match;
                 _playerList.Players = Client.StateManager
                     .GetUsers(Client.SelectedTournament)
@@ -387,11 +382,8 @@ namespace TournamentAssistant.UI.FlowCoordinators
                 {
                     RemoveSelfFromMatch();
                 }
-                // Map updates arrive before the load_song request
-                // Let that path initialize the detail view for new maps
                 else if (_songDetail && _songDetail.isInViewControllerHierarchy &&
-                         match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null &&
-                         !selectedMapChanged)
+                    match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null)
                 {
                     await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
                     {

--- a/TournamentAssistant/UI/ViewControllers/SongDetail.cs
+++ b/TournamentAssistant/UI/ViewControllers/SongDetail.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TMPro;
 using TournamentAssistant.Utilities;
+using TournamentAssistantShared.Models;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -193,9 +194,25 @@ namespace TournamentAssistant.UI.ViewControllers
             SetBeatmapLevel(_selectedLevel);
         }
 
-        private void SetBeatmapLevel(IBeatmapLevel beatmapLevel)
+        public void SetSelectedSong(IBeatmapLevel selectedLevel, Map map)
         {
-            if (beatmapLevel.beatmapLevelData.difficultyBeatmapSets.Any(x => x.beatmapCharacteristic == _playerDataModel.playerData.lastSelectedBeatmapCharacteristic))
+            buttonsRect.gameObject.SetActive(!DisablePlayButton);
+
+            _selectedLevel = selectedLevel;
+            controlsRect.gameObject.SetActive(true);
+            charactertisticControlBlocker.gameObject.SetActive(DisableCharacteristicControl);
+            difficultyControlBlocker.gameObject.SetActive(DisableDifficultyControl);
+
+            SetBeatmapLevel(_selectedLevel, map.GameplayParameters.Beatmap.Characteristic.SerializedName, map.GameplayParameters.Beatmap.Difficulty);
+        }
+
+        private void SetBeatmapLevel(IBeatmapLevel beatmapLevel, string preferredCharacteristic = null, int? preferredDifficulty = null)
+        {
+            if (preferredCharacteristic != null && preferredDifficulty != null)
+            {
+                _selectedDifficultyBeatmap = SongUtils.GetClosestDifficultyPreferLower(beatmapLevel, (BeatmapDifficulty)preferredDifficulty.Value, preferredCharacteristic);
+            }
+            else if (beatmapLevel.beatmapLevelData.difficultyBeatmapSets.Any(x => x.beatmapCharacteristic == _playerDataModel.playerData.lastSelectedBeatmapCharacteristic))
             {
                 _selectedDifficultyBeatmap = SongUtils.GetClosestDifficultyPreferLower(beatmapLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _playerDataModel.playerData.lastSelectedBeatmapCharacteristic.serializedName);
             }
@@ -223,7 +240,19 @@ namespace TournamentAssistant.UI.ViewControllers
 
         public void SetSelectedCharacteristic(string serializedName)
         {
+            if (_beatmapCharacteristics.Count == 0)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic '{serializedName}' because there are no available characteristics");
+                return;
+            }
+
             var characteristicIndex = _beatmapCharacteristics.FindIndex(x => x.serializedName == serializedName);
+            if (characteristicIndex < 0 || characteristicIndex >= _beatmapCharacteristics.Count)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic '{serializedName}' because it is not available");
+                return;
+            }
+
             characteristicControl.SelectCellWithNumber(characteristicIndex);
             SetSelectedCharacteristic(null, characteristicIndex);
         }
@@ -231,10 +260,24 @@ namespace TournamentAssistant.UI.ViewControllers
         [UIAction("characteristic-selected")]
         public void SetSelectedCharacteristic(IconSegmentedControl _, int index)
         {
+            if (_beatmapCharacteristics.Count == 0)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic index {index} because there are no available characteristics");
+                return;
+            }
+
+            if (index < 0 || index >= _beatmapCharacteristics.Count)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic index {index} because it is outside available characteristic count {_beatmapCharacteristics.Count}");
+                return;
+            }
+
             _playerDataModel.playerData.SetLastSelectedBeatmapCharacteristic(_beatmapCharacteristics[index]);
 
             var diffBeatmaps = _selectedLevel.beatmapLevelData.GetDifficultyBeatmapSet(_beatmapCharacteristics[index]).difficultyBeatmaps;
-            var closestDifficulty = SongUtils.GetClosestDifficultyPreferLower(_selectedLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _beatmapCharacteristics[index].serializedName);
+            var closestDifficulty = _selectedDifficultyBeatmap != null && _selectedDifficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic == _beatmapCharacteristics[index]
+                ? _selectedDifficultyBeatmap
+                : SongUtils.GetClosestDifficultyPreferLower(_selectedLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _beatmapCharacteristics[index].serializedName);
 
             var extraData = Collections.RetrieveExtraSongData(Collections.hashForLevelID(_selectedLevel.levelID));
             if (extraData != null)

--- a/TournamentAssistant/UI/ViewControllers/SongDetail.cs
+++ b/TournamentAssistant/UI/ViewControllers/SongDetail.cs
@@ -182,18 +182,7 @@ namespace TournamentAssistant.UI.ViewControllers
             }
         }
 
-        public void SetSelectedSong(IBeatmapLevel selectedLevel)
-        {
-            buttonsRect.gameObject.SetActive(!DisablePlayButton);
-
-            _selectedLevel = selectedLevel;
-            controlsRect.gameObject.SetActive(true);
-            charactertisticControlBlocker.gameObject.SetActive(DisableCharacteristicControl);
-            difficultyControlBlocker.gameObject.SetActive(DisableDifficultyControl);
-
-            SetBeatmapLevel(_selectedLevel);
-        }
-
+        // selectedLevel for the level data, map for desired characteristic and difficulty
         public void SetSelectedSong(IBeatmapLevel selectedLevel, Map map)
         {
             buttonsRect.gameObject.SetActive(!DisablePlayButton);

--- a/TournamentAssistant/Utilities/SongUtils.cs
+++ b/TournamentAssistant/Utilities/SongUtils.cs
@@ -35,7 +35,7 @@ namespace TournamentAssistant.Utilities
         public static IDifficultyBeatmap GetClosestDifficultyPreferLower(IBeatmapLevel level, BeatmapDifficulty difficulty, string characteristic)
         {
             // First, look at the characteristic parameter. If there's something useful in there, we try to use it, but fall back to Standard
-            var desiredCharacteristic = level.previewDifficultyBeatmapSets.FirstOrDefault(x => x.beatmapCharacteristic.serializedName == characteristic).beatmapCharacteristic ?? level.previewDifficultyBeatmapSets.First().beatmapCharacteristic;
+            var desiredCharacteristic = level.previewDifficultyBeatmapSets.FirstOrDefault(x => x.beatmapCharacteristic.serializedName == characteristic)?.beatmapCharacteristic ?? level.previewDifficultyBeatmapSets.First().beatmapCharacteristic;
 
             var availableMaps =
                 level
@@ -51,6 +51,11 @@ namespace TournamentAssistant.Utilities
 
             ret ??= GetLowerDifficulty(availableMaps, difficulty, desiredCharacteristic);
             ret ??= GetHigherDifficulty(availableMaps, difficulty, desiredCharacteristic);
+
+            if (ret == null)
+            {
+                throw new InvalidOperationException($"No selectable beatmap found for characteristic '{desiredCharacteristic.serializedName}' near difficulty '{difficulty}'.");
+            }
 
             return ret;
         }
@@ -98,12 +103,15 @@ namespace TournamentAssistant.Utilities
         public static bool HasRequirements(IDifficultyBeatmap map)
         {
             var extras = Collections.RetrieveExtraSongData(map.level.levelID);
-            var requirements = extras?._difficulties.First(x => x._difficulty == map.difficulty).additionalDifficultyData._requirements;
+            var characteristic = map.parentDifficultyBeatmapSet.beatmapCharacteristic;
+            var requirements = extras?._difficulties
+                .FirstOrDefault(x => (x._beatmapCharacteristicName == characteristic.serializedName || x._beatmapCharacteristicName == characteristic.characteristicNameLocalizationKey) && x._difficulty == map.difficulty)
+                ?.additionalDifficultyData._requirements;
 
-            Logger.Debug($"{map.level.songName} is a custom level, checking for requirements on {map.difficulty}...");
+            Logger.Debug($"{map.level.songName} is a custom level, checking requirements for {characteristic.serializedName}/{map.difficulty}...");
             if ((requirements?.Count() > 0) && !requirements.All(Collections.capabilities.Contains))
             {
-                Logger.Debug($"At leat one requirement not met: {string.Join(" ", requirements)}");
+                Logger.Debug($"At leat one requirement not met: {string.Join(", ", requirements)}");
                 return false;
             }
             Logger.Debug("Requirements met");


### PR DESCRIPTION
- Apply map characteristic and difficulty during song detail initialization

- Avoid preemptive match update selection before load_song handles map changes

- Match custom requirement checks by characteristic and difficulty

- Guard unavailable characteristic selections