### PR TITLE
Fix song detail map selection (BeatmapKey version)

### DIFF
--- a/TournamentAssistant/UI/FlowCoordinators/QualifierCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/QualifierCoordinator.cs
@@ -219,13 +219,9 @@ namespace TournamentAssistant.UI.FlowCoordinators
         {
             _currentMap = map;
 
-            var loadedLevel = SongUtils.masterLevelList.FirstOrDefault(x => x.levelID.ToUpper() == map.GameplayParameters.Beatmap.LevelId.ToUpper());
-
             PresentViewController(_songDetail, () =>
             {
-                _songDetail.SetSelectedSong(loadedLevel);
-                _songDetail.SetSelectedCharacteristic(map.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                _songDetail.SetSelectedDifficulty(map.GameplayParameters.Beatmap.Difficulty);
+                _songDetail.SetSelectedSong(map);
 
                 _gameplaySetupViewController.Setup(true, true, true, false, PlayerSettingsPanelController.PlayerSettingsPanelLayout.Singleplayer);
                 SetLeftScreenViewController(_gameplaySetupViewController, ViewController.AnimationType.In);

--- a/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
@@ -305,10 +305,14 @@ namespace TournamentAssistant.UI.FlowCoordinators
 
         private async void SongSelection_SongSelected(string levelId)
         {
-            var loadedLevel = SongUtils.masterLevelList.FirstOrDefault(x => x.levelID.ToUpper() == levelId.ToUpper());
-
             await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
             {
+                if (Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId?.ToUpper() != levelId.ToUpper())
+                {
+                    Logger.Error($"Unable to show loaded song '{levelId}' because the selected match map is '{Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId}'");
+                    return;
+                }
+
                 // Load the song, then display the detail info
                 if (!_songDetail.isInViewControllerHierarchy)
                 {
@@ -317,9 +321,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
                         _songDetail.DisableCharacteristicControl = true;
                         _songDetail.DisableDifficultyControl = true;
                         _songDetail.DisablePlayButton = true;
-                        _songDetail.SetSelectedSong(loadedLevel);
-                        _songDetail.SetSelectedCharacteristic(Match.SelectedMap.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                        _songDetail.SetSelectedDifficulty(Match.SelectedMap.GameplayParameters.Beatmap.Difficulty);
+                        _songDetail.SetSelectedSong(Match.SelectedMap);
                     }, immediately: true);
                 }
                 else
@@ -327,9 +329,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
                     _songDetail.DisableCharacteristicControl = true;
                     _songDetail.DisableDifficultyControl = true;
                     _songDetail.DisablePlayButton = true;
-                    _songDetail.SetSelectedSong(loadedLevel);
-                    _songDetail.SetSelectedCharacteristic(Match.SelectedMap.GameplayParameters.Beatmap.Characteristic.SerializedName);
-                    _songDetail.SetSelectedDifficulty(Match.SelectedMap.GameplayParameters.Beatmap.Difficulty);
+                    _songDetail.SetSelectedSong(Match.SelectedMap);
                 }
             });
         }
@@ -358,6 +358,11 @@ namespace TournamentAssistant.UI.FlowCoordinators
         {
             if (match.MatchEquals(Match))
             {
+                // Identify if this is a map change.
+                // Because map change events are followed by a load_song event,
+                // we want to avoid updating the detail view twice for the same map change
+                var selectedMapChanged = Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId != match.SelectedMap?.GameplayParameters?.Beatmap?.LevelId;
+
                 Match = match;
                 _playerList.Players = Client.StateManager
                     .GetUsers(Client.SelectedTournament)
@@ -380,8 +385,11 @@ namespace TournamentAssistant.UI.FlowCoordinators
                 {
                     RemoveSelfFromMatch();
                 }
+                // Map updates arrive before the load_song request
+                // Let that path initialize the detail view for new maps
                 else if (_songDetail && _songDetail.isInViewControllerHierarchy &&
-                         match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null)
+                         match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null &&
+                         !selectedMapChanged)
                 {
                     await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
                     {

--- a/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
+++ b/TournamentAssistant/UI/FlowCoordinators/RoomCoordinator.cs
@@ -358,9 +358,7 @@ namespace TournamentAssistant.UI.FlowCoordinators
         {
             if (match.MatchEquals(Match))
             {
-                // Identify if this is a map change.
-                // Because map change events are followed by a load_song event,
-                // we want to avoid updating the detail view twice for the same map change
+                // Check if the map changed
                 var selectedMapChanged = Match?.SelectedMap?.GameplayParameters?.Beatmap?.LevelId != match.SelectedMap?.GameplayParameters?.Beatmap?.LevelId;
 
                 Match = match;
@@ -385,11 +383,9 @@ namespace TournamentAssistant.UI.FlowCoordinators
                 {
                     RemoveSelfFromMatch();
                 }
-                // Map updates arrive before the load_song request
-                // Let that path initialize the detail view for new maps
                 else if (_songDetail && _songDetail.isInViewControllerHierarchy &&
                          match.SelectedMap != null && match.SelectedMap.GameplayParameters.Beatmap.Characteristic != null &&
-                         !selectedMapChanged)
+                         selectedMapChanged)
                 {
                     await UnityMainThreadTaskScheduler.Factory.StartNew(() =>
                     {

--- a/TournamentAssistant/UI/ViewControllers/SongDetail.cs
+++ b/TournamentAssistant/UI/ViewControllers/SongDetail.cs
@@ -15,6 +15,7 @@ using TMPro;
 using TournamentAssistant.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
+using TournamentAssistantShared.Models;
 
 namespace TournamentAssistant.UI.ViewControllers
 {
@@ -208,11 +209,28 @@ namespace TournamentAssistant.UI.ViewControllers
             SetBeatmapLevel(selectedLevel);
         }
 
-        private void SetBeatmapLevel(BeatmapLevel beatmapLevel)
+        public void SetSelectedSong(Map map)
+        {
+            var selectedLevel = SongUtils.masterLevelList.FirstOrDefault(x => x.levelID.ToUpper() == map.GameplayParameters.Beatmap.LevelId.ToUpper());
+
+            buttonsRect.gameObject.SetActive(!DisablePlayButton);
+
+            controlsRect.gameObject.SetActive(true);
+            charactertisticControlBlocker.gameObject.SetActive(DisableCharacteristicControl);
+            difficultyControlBlocker.gameObject.SetActive(DisableDifficultyControl);
+
+            SetBeatmapLevel(selectedLevel, map.GameplayParameters.Beatmap.Characteristic.SerializedName, map.GameplayParameters.Beatmap.Difficulty);
+        }
+
+        private void SetBeatmapLevel(BeatmapLevel beatmapLevel, string preferredCharacteristic = null, int? preferredDifficulty = null)
         {
             _selectedLevel = beatmapLevel;
 
-            if (beatmapLevel.GetBeatmapKeys().Any(x => x.beatmapCharacteristic == _playerDataModel.playerData.lastSelectedBeatmapCharacteristic))
+            if (preferredCharacteristic != null && preferredDifficulty != null)
+            {
+                _selectedKey = SongUtils.GetClosestDifficultyPreferLower(beatmapLevel, (BeatmapDifficulty)preferredDifficulty.Value, preferredCharacteristic);
+            }
+            else if (beatmapLevel.GetBeatmapKeys().Any(x => x.beatmapCharacteristic == _playerDataModel.playerData.lastSelectedBeatmapCharacteristic))
             {
                 _selectedKey = SongUtils.GetClosestDifficultyPreferLower(beatmapLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _playerDataModel.playerData.lastSelectedBeatmapCharacteristic.serializedName);
             }
@@ -240,7 +258,19 @@ namespace TournamentAssistant.UI.ViewControllers
 
         public void SetSelectedCharacteristic(string serializedName)
         {
+            if (_beatmapCharacteristics.Count == 0)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic '{serializedName}' because there are no available characteristics");
+                return;
+            }
+
             var characteristicIndex = _beatmapCharacteristics.FindIndex(x => x.serializedName == serializedName);
+            if (characteristicIndex < 0 || characteristicIndex >= _beatmapCharacteristics.Count)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic '{serializedName}' because it is not available");
+                return;
+            }
+
             characteristicControl.SelectCellWithNumber(characteristicIndex);
             SetSelectedCharacteristic(null, characteristicIndex);
         }
@@ -248,10 +278,24 @@ namespace TournamentAssistant.UI.ViewControllers
         [UIAction("characteristic-selected")]
         public void SetSelectedCharacteristic(IconSegmentedControl _, int index)
         {
+            if (_beatmapCharacteristics.Count == 0)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic index {index} because there are no available characteristics");
+                return;
+            }
+
+            if (index < 0 || index >= _beatmapCharacteristics.Count)
+            {
+                TournamentAssistantShared.Logger.Error($"Unable to select characteristic index {index} because it is outside available characteristic count {_beatmapCharacteristics.Count}");
+                return;
+            }
+
             _playerDataModel.playerData.SetLastSelectedBeatmapCharacteristic(_beatmapCharacteristics[index]);
 
             var difficulties = _selectedLevel.GetDifficulties(_beatmapCharacteristics[index]);
-            var closestDifficulty = SongUtils.GetClosestDifficultyPreferLower(_selectedLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _beatmapCharacteristics[index].serializedName);
+            var closestDifficulty = _selectedKey is BeatmapKey selectedKey && selectedKey.beatmapCharacteristic == _beatmapCharacteristics[index]
+                ? selectedKey
+                : SongUtils.GetClosestDifficultyPreferLower(_selectedLevel, _playerDataModel.playerData.lastSelectedBeatmapDifficulty, _beatmapCharacteristics[index].serializedName);
 
             var extraData = Collections.GetCustomLevelSongData(Collections.GetCustomLevelHash(_selectedLevel.levelID));
             if (extraData != null)

--- a/TournamentAssistant/UI/ViewControllers/SongDetail.cs
+++ b/TournamentAssistant/UI/ViewControllers/SongDetail.cs
@@ -198,17 +198,6 @@ namespace TournamentAssistant.UI.ViewControllers
             }
         }
 
-        public void SetSelectedSong(BeatmapLevel selectedLevel)
-        {
-            buttonsRect.gameObject.SetActive(!DisablePlayButton);
-
-            controlsRect.gameObject.SetActive(true);
-            charactertisticControlBlocker.gameObject.SetActive(DisableCharacteristicControl);
-            difficultyControlBlocker.gameObject.SetActive(DisableDifficultyControl);
-
-            SetBeatmapLevel(selectedLevel);
-        }
-
         public void SetSelectedSong(Map map)
         {
             var selectedLevel = SongUtils.masterLevelList.FirstOrDefault(x => x.levelID.ToUpper() == map.GameplayParameters.Beatmap.LevelId.ToUpper());

--- a/TournamentAssistant/Utilities/SongUtils.cs
+++ b/TournamentAssistant/Utilities/SongUtils.cs
@@ -51,7 +51,12 @@ namespace TournamentAssistant.Utilities
             ret ??= GetLowerDifficulty(availableMaps, difficulty, desiredCharacteristic);
             ret ??= GetHigherDifficulty(availableMaps, difficulty, desiredCharacteristic);
 
-            return ret.Value;
+            if (ret is BeatmapKey selectedKey)
+            {
+                return selectedKey;
+            }
+
+            throw new InvalidOperationException($"No selectable beatmap found for characteristic '{desiredCharacteristic.serializedName}' near difficulty '{difficulty}'.");
         }
 
         // Returns the next-lowest difficulty to the one provided
@@ -101,12 +106,14 @@ namespace TournamentAssistant.Utilities
         public static bool HasRequirements(BeatmapKey key)
         {
             var extras = Collections.GetCustomLevelSongData(key.levelId);
-            var requirements = extras?._difficulties.First(x => x._difficulty == key.difficulty).additionalDifficultyData._requirements;
+            var requirements = extras?._difficulties
+                .FirstOrDefault(x => x._beatmapCharacteristicName == key.beatmapCharacteristic.serializedName && x._difficulty == key.difficulty)
+                ?.additionalDifficultyData._requirements;
 
-            Logger.Debug($"{key.levelId} is a custom level, checking for requirements on {key.difficulty}...");
+            Logger.Debug($"{key.levelId} is a custom level, checking requirements for {key.beatmapCharacteristic.serializedName}/{key.difficulty}...");
             if ((requirements?.Count() > 0) && !requirements.All(Collections.capabilities.Contains))
             {
-                Logger.Debug($"At leat one requirement not met: {string.Join(" ", requirements)}");
+                Logger.Debug($"At leat one requirement not met: {string.Join(", ", requirements)}");
                 return false;
             }
             Logger.Debug("Requirements met");

--- a/TournamentAssistant/Utilities/SongUtils.cs
+++ b/TournamentAssistant/Utilities/SongUtils.cs
@@ -51,12 +51,12 @@ namespace TournamentAssistant.Utilities
             ret ??= GetLowerDifficulty(availableMaps, difficulty, desiredCharacteristic);
             ret ??= GetHigherDifficulty(availableMaps, difficulty, desiredCharacteristic);
 
-            if (ret is BeatmapKey selectedKey)
+            if (ret is not BeatmapKey selectedKey)
             {
-                return selectedKey;
+                throw new InvalidOperationException($"No selectable beatmap found for characteristic '{desiredCharacteristic.serializedName}' near difficulty '{difficulty}'.");
             }
 
-            throw new InvalidOperationException($"No selectable beatmap found for characteristic '{desiredCharacteristic.serializedName}' near difficulty '{difficulty}'.");
+            return selectedKey;
         }
 
         // Returns the next-lowest difficulty to the one provided


### PR DESCRIPTION
- Apply map characteristic and difficulty during song detail initialization

- Avoid preemptive match update selection before load_song handles map changes

- Match custom requirement checks by characteristic and difficulty

- Guard unavailable characteristic selections