### PR TITLE
fix: remove fallback calculation, leave njs as 0 if not found

### DIFF
--- a/TournamentAssistant/UI/ViewControllers/SongDetail.cs
+++ b/TournamentAssistant/UI/ViewControllers/SongDetail.cs
@@ -154,10 +154,6 @@ namespace TournamentAssistant.UI.ViewControllers
                             {
                                 njs = _selectedDifficultyBeatmap.noteJumpMovementSpeed;
                             }
-                            else
-                            {
-                                njs = BeatmapDifficultyMethods.NoteJumpMovementSpeed(SelectedDifficulty);
-                            }
 
                             var jumpDistance = SongUtils.GetJumpDistance(_selectedLevel.beatsPerMinute, njs, _selectedDifficultyBeatmap.noteJumpStartBeatOffset);
                             npsText.text = (beatmapData.cuttableNotesCount / _selectedLevel.beatmapLevelData.audioClip.length).ToString("0.00");


### PR DESCRIPTION
Removed fallback for note jump movement speed calculation.